### PR TITLE
Commit dist when changes occurred.

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -2,6 +2,8 @@ name: Package Action
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - 'dist/**'
   workflow_dispatch:


### PR DESCRIPTION
# Description

Enable committing changes to the `dist` directory on pushes to main.

The alternative is to have a check step which will detect if there's any changes to the dist file and require users to _manually_ run `npm run all` locally + committing this before merging.

Successful action run: https://github.com/stackrox/central-login/actions/runs/6741999434/job/18327406312
Resulting commit: https://github.com/stackrox/central-login/pull/5/commits/cad050307b8035542ad601c7fb6b2f6d8d4c2363