### PR TITLE
chore(deps): increase dependabot PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
 
   - package-ecosystem: npm
     directory: /
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     schedule:
       interval: daily


### PR DESCRIPTION
# Description

Increase the PR limit for dependabot to 5 instead of only 1.
