### PR TITLE
chore: use roxctl-installer-action

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,8 +2,9 @@ name: E2E
 
 on:
   push:
-    branches:
-      - main
+    # TODO(dhaus): Temporarily disable this to test the workflow in PR.
+    #branches:
+    #  - main
   schedule:
     - cron: '0 5 * * 0'
 
@@ -101,9 +102,9 @@ jobs:
           endpoint: https://localhost:8000
           skip-tls-verify: true
 
-      - name: Fetch roxctl and run roxctl central whoami
+      - name: Install roxctl
+        uses: stackrox/roxctl-installer-action@v1
+
+      - name: Check the current user with roxctl
         run: |
-          curl -k -u admin:${ROX_PASSWORD} https://localhost:8000/api/cli/download/roxctl-linux --output ./roxctl
-          chmod +x ./roxctl
-          echo $ROX_ENDPOINT
-          ./roxctl central whoami
+          roxctl central whoami

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,8 @@ name: E2E
 
 on:
   push:
-    # TODO(dhaus): Temporarily disable this to test the workflow in PR.
-    #branches:
-    #  - main
+    branches:
+      - main
   schedule:
     - cron: '0 5 * * 0'
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ permissions:
 Before being able to exchange tokens, the ACS Central instance needs to be configured to allow exchanging tokens
 originating from GitHub Action workflow runs.
 
-At the current time, this only works via API, see the sample configuration below:
+For more information on how to configure this, follow the [RHACS documentation](https://docs.openshift.com/acs/4.4/operating/manage-user-access/configure-short-lived-access.html).
 
+Below is a sample configuration via API you can use:
 ```bash
 curl \
   https://<central-endpoint>/v1/auth/m2m \
@@ -97,10 +98,16 @@ After the central login step has succeeded, the following environment variables 
 For verifying everything works correctly, the example below can be used:
 
 ```yaml
-    - name: Central Login
+    - name: Login to Central
       uses: stackrox/central-login@v1
       with:
         endpoint: https://<central-endpoint>:443
+
+    - name: Install roxctl from Central
+      uses: stackrox/roxctl-installer-action@v1
+      with:
+        central-endpoint: https://${{ env.ROX_ENDPOINT }}
+        central-token: ${{ env.ROX_API_TOKEN }}
 
     - name: roxctl central whoami
       run: |


### PR DESCRIPTION
# Description

Use the newly added `stackrox/roxctl-installer-action` within the e2e tests & reference it within docs.

Sample E2E run on this PR with the installer action: https://github.com/stackrox/central-login/actions/runs/8741715365/job/23991936219