### PR TITLE
chore: run e2e tests for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     open-pull-requests-limit: 1
     schedule:
       interval: daily
+    labels:
+      - "dependencies"
+      - "e2e"
+      - "github_actions"
 
   - package-ecosystem: npm
     directory: /
@@ -15,3 +19,7 @@ updates:
       typescript-eslint:
         patterns:
           - "@typescript-eslint/*"
+    labels:
+      - "dependencies"
+      - "e2e"
+      - "javascript"


### PR DESCRIPTION
# Description

Run e2e tests for dependabot PRs. The reason is that otherwise it's hard to tell if dependency bumps will break the workflow.