### PR TITLE
chore(deps-dev): Revert "chore(deps-dev): bump typescript from 5.5.4 to 5.6.2 (#239)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "js-yaml": "^4.1.0",
         "prettier": "^3.3.3",
         "ts-jest": "^29.2.5",
-        "typescript": "^5.6.2"
+        "typescript": "^5.5.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -6359,9 +6359,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "js-yaml": "^4.1.0",
     "prettier": "^3.3.3",
     "ts-jest": "^29.2.5",
-    "typescript": "^5.6.2"
+    "typescript": "^5.5.4"
   }
 }


### PR DESCRIPTION
This reverts commit 552f7737b5fcc761a35c9f61e6a9e24c1e7ca34e.

# Description

The reverted commit breaks the package action run agains master.
It seems to introduce type semantics with which axios is not compatible.

<!--
Describe your changes briefly here.
-->