### PR TITLE
chore: dependabot weekly interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: /
     open-pull-requests-limit: 1
     schedule:
-      interval: daily
+      interval: weekly
     labels:
       - "dependencies"
       - "e2e"
@@ -14,7 +14,7 @@ updates:
     directory: /
     open-pull-requests-limit: 5
     schedule:
-      interval: daily
+      interval: weekly
     groups:
       typescript-eslint:
         patterns:


### PR DESCRIPTION
# Description

<!--
Describe your changes briefly here.
-->
Daily updates seem to generate a bit too much work given our release cadence for the action. Let's set the interval to weekly to save us some effort.