### PR TITLE
tests: pin used central version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
           flavor: qa-demo
           name: central-login-${{ github.run_id }}
           lifespan: 1h
-          args: main-image=quay.io/stackrox-io/main:latest
+          args: main-image=quay.io/stackrox-io/main:4.6.1
           wait: "true"
           no-slack: "true"
 


### PR DESCRIPTION
# Description

<!--
Describe your changes briefly here.
-->
It seems the use of the latest main image lately prevented the test cluster from starting.
This PR pins it to the current version used by infra.