### PR TITLE
chore(deps): drop axios-retry dependency and implement retry logic in own code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "^1.11.1",
         "@actions/http-client": "^2.2.3",
         "axios": "^1.10.0",
-        "axios-retry": "^4.5.0"
+        "is-retry-allowed": "^2.2.0"
       },
       "devDependencies": {
         "@stylistic/eslint-plugin": "^4.4.1",
@@ -3117,17 +3117,6 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
-      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
-      "dependencies": {
-        "is-retry-allowed": "^2.2.0"
-      },
-      "peerDependencies": {
-        "axios": "0.x || 1.x"
       }
     },
     "node_modules/axobject-query": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@actions/core": "^1.11.1",
     "@actions/http-client": "^2.2.3",
     "axios": "^1.10.0",
-    "axios-retry": "^4.5.0"
+    "is-retry-allowed": "^2.2.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,7 +74,7 @@ async function postWithRetries(
   maxRetries: number = 3,
   baseDelay: number = 2000
 ): Promise<string> {
-  let lastError: any;
+  let lastError;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       if (attempt > 0) {
@@ -95,7 +95,7 @@ async function postWithRetries(
       )
 
       return result.data['accessToken'];
-    } catch (error: any) {
+    } catch (error) {
       lastError = error;
       if (isRetryableError(error) && attempt < maxRetries) {
         continue;
@@ -106,7 +106,7 @@ async function postWithRetries(
   return Promise.reject(lastError);
 }
 
-function isRetryableError(error: any): boolean {
+function isRetryableError(error): boolean {
   core.warning(error);
   if (error.code === 'ECONNABORTED') {
     return false;


### PR DESCRIPTION
# Description

<!--
Describe your changes briefly here.
-->
The axios-retry dependency uses an different axios version than the one used as direct dependency.
This causes the build and release process to break on typescript type validation (see https://github.com/stackrox/central-login/actions/runs/15704285358/job/44246330400 for an example).
In order to maintain the ability to deliver the github action, the faulty dependency is dropped and the associated logic is implemented in the main code base.