### PR TITLE
debug issues with cert

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,7 +36,7 @@ jobs:
       
       - name: Install Stackrox
         env:
-          MAIN_IMAGE_TAG: "4.9.x-336-gcd5279edf2"
+          MAIN_IMAGE_TAG: "4.9.x-335-g000ea2786f"
           SENSOR_HELM_DEPLOY: "true"
           ROX_SCANNER_V4: "false"
         run: |


### PR DESCRIPTION
roxctl is ignoring installed certificates and that results with following error
```sql
ERROR:	getting auth status: rpc error: code = Unavailable desc = connection error: 
desc = "transport: authentication handshake failed: verifying Central certificate errors: 
[x509: certificate signed by unknown authority, x509: certificate signed by unknown authority]"
```
The breaking change was introduced in 
- https://github.com/stackrox/stackrox/pull/15173/
```c
cd5279edf2236ee1f8dca24db34720bf5a3fd903 is the first bad commit
commit cd5279edf2236ee1f8dca24db34720bf5a3fd903
Author: Michaël <github@parameta.lol>
Date:   Tue Jul 29 14:02:42 2025 +0200

    ROX-28673: refactor roxctl tlsconfigopts (#15173)

 roxctl/common/client.go                       |   2 +-
 roxctl/common/connection.go                   |  29 +++++++++++++++----
 roxctl/common/connection_test.go              |  65 +++++++++++++++++++++++++++++++++++++++++
 roxctl/common/environment/environment-impl.go |   2 +-
 roxctl/common/tls.go                          | 140 +++++++++++++++++++++++++++-------------------------------------------------------------
 5 files changed, 134 insertions(+), 104 deletions(-)
```