### PR TITLE
chore(deps): increase dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: /
     open-pull-requests-limit: 1
     schedule:
-      interval: weekly
+      interval: daily
     labels:
       - "dependencies"
       - "e2e"
@@ -14,7 +14,7 @@ updates:
     directory: /
     open-pull-requests-limit: 1
     schedule:
-      interval: weekly
+      interval: daily
     groups:
       typescript-eslint:
         patterns:


### PR DESCRIPTION
# Description

<!--
Describe your changes briefly here.
-->

Considering that the number of parallel dependabot PRs was reduced to 1 (to limit the rebase workload), the run frequency is increased again in order to avoid missing dependency upgrades (there were about 5 weekly PRs).