### PR TITLE
chore(deps): increase dependabot parallelism

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,8 @@ updates:
 
   - package-ecosystem: npm
     directory: /
-    open-pull-requests-limit: 1
+    # unblock other updates until eslint-plugin-github supports eslint 10
+    open-pull-requests-limit: 2
     schedule:
       interval: daily
     groups:


### PR DESCRIPTION
# Description

<!--
Describe your changes briefly here.
-->

Temporary unblock other dependencies until eslint-plugin-github supports eslint 10.