### PR TITLE
chore(deps): bump eslint-plugin-jest to 29.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@vercel/ncc": "^0.38.4",
         "eslint": "^9.39.2",
         "eslint-plugin-github": "^6.0.0",
-        "eslint-plugin-jest": "^29.15.0",
+        "eslint-plugin-jest": "^29.15.1",
         "eslint-plugin-prettier": "^5.5.5",
         "jest": "^30.4.2",
         "js-yaml": "^4.1.1",
@@ -4204,9 +4204,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "29.15.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.0.tgz",
-      "integrity": "sha512-ZCGr7vTH2WSo2hrK5oM2RULFmMruQ7W3cX7YfwoTiPfzTGTFBMmrVIz45jZHd++cGKj/kWf02li/RhTGcANJSA==",
+      "version": "29.15.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
+      "integrity": "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4219,7 +4219,7 @@
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "jest": "*",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <7.0.0"
       },
       "peerDependenciesMeta": {
         "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@vercel/ncc": "^0.38.4",
     "eslint": "^9.39.2",
     "eslint-plugin-github": "^6.0.0",
-    "eslint-plugin-jest": "^29.15.0",
+    "eslint-plugin-jest": "^29.15.1",
     "eslint-plugin-prettier": "^5.5.5",
     "jest": "^30.4.2",
     "js-yaml": "^4.1.1",


### PR DESCRIPTION
# Description

<!--
Describe your changes briefly here.
-->

The constraints on dependencies of the currently pulled version blocks #562 