### PR TITLE
chore: bump Node.js from 20 to 24 in workflows and esbuild target

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup Node.js 20.x
-        uses: actions/setup-node@v6.4.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version-file: package.json
 
       - name: Deps
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,10 +25,10 @@ jobs:
           token: ${{ secrets.RHACS_BOT_GITHUB_TOKEN }}
           ref: ${{ github.ref_name }}
 
-      - name: Setup Node.js 20.x
-        uses: actions/setup-node@v6.4.0
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version-file: package.json
 
       - name: Deps
         run: |

--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
     required: false
     description: "Skip TLS certificate verification for Central's API Endpoint"
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
     "format": "prettier --write '**/*.ts' '**/*.yml'",
     "format-check": "prettier --check '**/*.ts' '**/*.yml'",
     "lint": "eslint src/**/*.ts --fix",
-    "package": "esbuild src/main.ts --bundle --platform=node --target=node20 --outfile=dist/index.js --sourcemap",
+    "package": "esbuild src/main.ts --bundle --platform=node --target=node24 --outfile=dist/index.js --sourcemap",
     "all": "npm run build && npm run format && npm run lint && npm run package"
+  },
+  "engines": {
+    "node": ">=24"
   },
   "keywords": [],
   "author": "Red Hat",


### PR DESCRIPTION
# Description

Bump to node 24. Closes #588 

Add engines field to package.json as the single source of truth for the Node version and reference it via node-version-file in workflows. Also unpin setup-node from v6.4.0 to v6.